### PR TITLE
Do not skip unpublished Gem in CycloneDX output

### DIFF
--- a/cyclonedx-ruby.gemspec
+++ b/cyclonedx-ruby.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'cyclonedx-ruby'
-  spec.version     = '1.2.0'
-  spec.date        = '2023-07-14'
+  spec.version     = '1.2.0.lineaje'
+  spec.date        = '2023-11-14'
   spec.summary     = 'CycloneDX software bill-of-material (SBoM) generation utility'
   spec.description = 'CycloneDX is a lightweight software bill-of-material (SBOM) specification designed for use in application security contexts and supply chain component analysis. This Gem generates CycloneDX BOMs from Ruby projects.'
-  spec.authors     = ['Joseph Kobti', 'Steve Springett']
-  spec.email       = 'josephkobti@outlook.com'
+  spec.authors     = ['Joseph Kobti', 'Steve Springett', 'Abhisek Sanyal']
+  spec.email       = 'support@lineaje.com'
   spec.homepage    = 'https://github.com/CycloneDX/cyclonedx-ruby-gem'
   spec.license     = 'Apache-2.0'
 

--- a/lib/bom_builder.rb
+++ b/lib/bom_builder.rb
@@ -162,7 +162,11 @@ class Bombuilder
       object.version = dependency.version
       object.purl = purl(object.name, object.version)
       gem = get_gem(object.name, object.version)
-      next if gem.nil?
+      # If gem is unpublished, or if this version is unavailable, then add basic gem information instead of skipping it
+      if gem.nil?
+        @gems.push(object)
+        next
+      end
 
       if gem['licenses']&.length&.positive?
         if @licenses_list.include? gem['licenses'].first

--- a/lib/bom_component.rb
+++ b/lib/bom_component.rb
@@ -17,13 +17,21 @@ class BomComponent
       "type": DEFAULT_TYPE,
       "name": @name,
       "version": @version,
-      "description": @description,
-      "purl": @purl,
-      "hashes": [
-          "alg": HASH_ALG,
-          "content": @hash
-      ]
+      "purl": @purl
     }
+
+    # Add description only if it is available
+    if @description
+      component_hash[:"description"] = @description
+    end
+
+    # Add hash only if it is available
+    if @hash
+      component_hash[:"hashes"] = [
+        "alg": HASH_ALG,
+        "content": @hash
+      ]
+    end
 
     if @gem['license_id']
       component_hash[:"licenses"] = [


### PR DESCRIPTION
In case the Gem is unpublished or if this version is unavailable, then add basic Gem information in the CycloneDX output instead of skipping it